### PR TITLE
Patch enum

### DIFF
--- a/src/plugins/manager/switch.py
+++ b/src/plugins/manager/switch.py
@@ -66,6 +66,7 @@ async def _(bot: Bot, event: GroupMessageEvent, args: Message = CommandArg()):
     group_id = to_uuid(str(event.group_id))
     async with get_session() as session:
         group = await get_or_create_switch(group_id, session)
+        session.add(group)
         setattr(group, func, status)
         await session.commit()
-        await func_switch.finish(f"{func} 已设置为 {status!s}")
+    await func_switch.finish(f"{func} 已设置为 {status!s}")

--- a/src/plugins/manager/switch.py
+++ b/src/plugins/manager/switch.py
@@ -40,7 +40,7 @@ func_switch = on_command(
 @func_switch.handle()
 async def _(bot: Bot, event: GroupMessageEvent, args: Message = CommandArg()):
     msg = args.extract_plain_text().strip().split()
-    if len(msg) != 2:
+    if not len(msg) >= 1:
         await func_switch.finish(
             "请提供功能名称和状态，例如：/set_func fishing on"
             + f"\n可用：{', '.join(list(FuncEnum.__members__))}"
@@ -50,6 +50,10 @@ async def _(bot: Bot, event: GroupMessageEvent, args: Message = CommandArg()):
             f"功能名称错误，请使用以下功能：{', '.join(list(FuncEnum.__members__))}"
         )
     func: str = getattr(FuncEnum, msg[0]).value
+    if not len(msg) >= 2:
+        async with get_session() as session:
+            group = await get_or_create_switch(to_uuid(str(event.group_id)), session)
+            await func_switch.finish(f"{func} 当前状态为 {getattr(group, func)!s}")
     match msg[1].lower():
         case "on" | "enable" | "true" | "1" | "开启":
             status = True

--- a/src/plugins/manager/switch.py
+++ b/src/plugins/manager/switch.py
@@ -49,7 +49,7 @@ async def _(bot: Bot, event: GroupMessageEvent, args: Message = CommandArg()):
         await func_switch.finish(
             f"功能名称错误，请使用以下功能：{', '.join(list(FuncEnum.__members__))}"
         )
-    func = FuncEnum(msg[0]).value
+    func: str = getattr(FuncEnum, msg[0]).value
     match msg[1].lower():
         case "on" | "enable" | "true" | "1" | "开启":
             status = True

--- a/src/plugins/manager/switch.py
+++ b/src/plugins/manager/switch.py
@@ -40,7 +40,7 @@ func_switch = on_command(
 @func_switch.handle()
 async def _(bot: Bot, event: GroupMessageEvent, args: Message = CommandArg()):
     msg = args.extract_plain_text().strip().split()
-    if not len(msg) >= 1:
+    if len(msg) < 1:
         await func_switch.finish(
             "请提供功能名称和状态，例如：/set_func fishing on"
             + f"\n可用：{', '.join(list(FuncEnum.__members__))}"

--- a/suggar_utils/switch_models.py
+++ b/suggar_utils/switch_models.py
@@ -4,7 +4,7 @@ from collections.abc import Awaitable, Callable
 from enum import Enum
 
 from nonebot import require
-from nonebot.adapters.onebot.v11 import GroupMessageEvent
+from nonebot.adapters.onebot.v11 import GroupMessageEvent, MessageEvent
 from sqlalchemy import String, insert, select
 from sqlalchemy.orm import MappedColumn, mapped_column
 
@@ -60,10 +60,12 @@ def is_enabled(func_name: FuncEnum) -> Callable[..., Awaitable[bool]]:
     判断当前群组是否启用功能
     """
 
-    async def check(event: GroupMessageEvent) -> bool:
-        group_id = to_uuid(str(event.group_id))
-        async with get_session() as session:
-            data = await get_or_create_switch(group_id, session)
-            return getattr(data, func_name.value)
+    async def check(event: MessageEvent) -> bool:
+        if isinstance(event, GroupMessageEvent):
+            group_id = to_uuid(str(event.group_id))
+            async with get_session() as session:
+                data = await get_or_create_switch(group_id, session)
+                return getattr(data, func_name.value)
+        return True
 
     return check


### PR DESCRIPTION
## Sourcery 摘要

增强功能开关系统，支持状态查询并拓宽事件处理

新功能：
- 允许在 switch 命令中使用单个参数查询某个功能的当前启用/禁用状态

Bug 修复：
- 放宽参数数量验证，以允许仅状态查询，并使用 getattr 修正枚举值查找
- 确保在提交更改之前将开关记录添加到会话中

增强：
- 扩展 is_enabled 装饰器以接受任何 MessageEvent，并对非群组事件默认设置为 true

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the feature switch system by supporting status queries and broadening event handling

New Features:
- Allow querying a feature’s current enabled/disabled status with a single argument in the switch command

Bug Fixes:
- Relax argument count validation to permit status-only queries and correct enum value lookup using getattr
- Ensure switch record is added to the session before committing changes

Enhancements:
- Extend is_enabled decorator to accept any MessageEvent and default to true for non-group events

</details>