### PR TITLE
Refine eco2fishing conversion

### DIFF
--- a/src/plugins/fishing/__init__.py
+++ b/src/plugins/fishing/__init__.py
@@ -44,7 +44,7 @@ async def init_fish():
     await get_or_create_currency(FISHING_POINT)
     if config_manager.config.eco2fishing:
         logger.warning("正在将账户余额转换为钓鱼积分...")
-        accounts = await list_accounts()
+        accounts = await list_accounts(FISHING_POINT.id)
         account_balance = [
             (account.currency_id, account.balance) for account in accounts
         ]

--- a/src/plugins/fishing/__init__.py
+++ b/src/plugins/fishing/__init__.py
@@ -8,7 +8,7 @@ from nonebot_plugin_orm import get_session
 from nonebot_plugin_value import get_or_create_currency
 from nonebot_plugin_value.api.api_balance import (
     batch_add_balance,
-    batch_del_balance,
+    del_account,
     list_accounts,
 )
 
@@ -44,14 +44,14 @@ async def init_fish():
     await get_or_create_currency(FISHING_POINT)
     if config_manager.config.eco2fishing:
         logger.warning("正在将账户余额转换为钓鱼积分...")
-        accounts = await list_accounts(FISHING_POINT.id)
-        account_balance = [
-            (account.currency_id, account.balance) for account in accounts
+        accounts = await list_accounts()
+        account_balance: list[tuple[str, float]] = [
+            (account.id, account.balance) for account in accounts
         ]
-        await batch_del_balance(
-            account_balance,
-        )
+
         await batch_add_balance(account_balance, currency_id=FISHING_POINT.id)
+        for account in accounts:
+            await del_account(account.id)
         config_manager.config.eco2fishing = False
         await config_manager.save_config()
         await config_manager.reload_config()


### PR DESCRIPTION
## Sourcery 总结

通过切换到 `account.id` 进行余额映射、移除批量余额删除、在转换后单独删除账户以及添加类型提示，优化了钓鱼插件中的 eco2fishing 转换过程。

增强功能：
- 在聚合余额进行转换时，使用 `account.id` 而不是 `currency_id`
- 移除 `batch_del_balance` 调用，并在添加钓鱼点后单独删除每个账户
- 为 `account_balance` 列表添加显式类型注解

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the eco2fishing conversion process in the fishing plugin by switching to account.id for balance mapping, removing bulk balance deletion, deleting accounts individually post-conversion, and adding type hints.

Enhancements:
- Use account.id instead of currency_id when aggregating balances for conversion
- Remove batch_del_balance invocation and delete each account individually after adding fishing points
- Add explicit type annotation for the account_balance list

</details>