### PR TITLE
Fix fishing progress and update sell currency

### DIFF
--- a/src/plugins/fishing/command.py
+++ b/src/plugins/fishing/command.py
@@ -315,12 +315,12 @@ async def handle_sell(bot: Bot, event: MessageEvent, arg: Message = CommandArg()
         # 尝试按鱼名出售
         price = await sell_fish(event.user_id, fish_name=msg)
         if price:
-            await sell.send(f"成功出售所有 {msg}，获得{price}金币")
+            await sell.send(f"成功出售所有 {msg}，获得{price}钓鱼积分")
         else:
             # 尝试按品质出售
             price = await sell_fish(event.user_id, quality_name=msg)
             if price:
-                await sell.send(f"成功出售所有{msg}品质的鱼，获得{price}金币")
+                await sell.send(f"成功出售所有{msg}品质的鱼，获得{price}钓鱼积分")
             else:
                 return await sell.finish("没有这个品质/名字的鱼")
 

--- a/src/plugins/fishing/functions.py
+++ b/src/plugins/fishing/functions.py
@@ -24,7 +24,6 @@ async def get_user_progress(
         return data
     except json.JSONDecodeError:
         logger.warning(f"Invalid progress data: {progress}")
-        await refresh_progress(user_id, session)
         return {}
 
 
@@ -32,7 +31,10 @@ async def refresh_progress(user_id: int, session: AsyncSession):
     async with user_lock[user_id]:
         async with session:
             data = await get_user_data_pyd(user_id)
-            quality_dict: dict[str, list[str]] = {}
+            quality_dict: dict[str, list[str]] = await get_user_progress(
+                user_id, session
+            )
+
             for fish in data.fishes:
                 quality = fish.metadata.quality
                 name = fish.metadata.name


### PR DESCRIPTION
## Sourcery 概要

改进钓鱼插件以通过重用现有进度来防止进度数据丢失，并更新出售命令以显示钓鱼点数而非金币

增强：
- 移除在 JSON 解码错误时自动刷新进度的功能，以避免清除现有数据
- 在 `refresh_progress` 中从现有用户进度初始化品质字典，而非重置它
- 更新出售命令的响应以指示钓鱼点数而非金币

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve fishing plugin to prevent progress data loss by reusing existing progress and update sell command to display fishing points instead of coins

Enhancements:
- Remove automatic progress refresh on JSON decode errors to avoid wiping existing data
- Initialize quality dictionary in refresh_progress from existing user progress instead of resetting it
- Update sell command responses to indicate fishing points rather than coins

</details>